### PR TITLE
Reading a ConfigMap results in an RBAC problem

### DIFF
--- a/a-configmap.yaml
+++ b/a-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: default
+  name: a-configmap
+data:
+  foo: bar

--- a/a-configmap.yaml
+++ b/a-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: default
+  namespace: system
   name: a-configmap
 data:
   foo: bar

--- a/a-configmap.yaml
+++ b/a-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: system
+  namespace: guestbook-system
   name: a-configmap
 data:
   foo: bar

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,11 +1,20 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
   name: manager-role
+  namespace: system
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - webapp.my.domain
   resources:
@@ -32,20 +41,3 @@ rules:
   - get
   - patch
   - update
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  name: manager-role
-  namespace: system
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -39,17 +39,13 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: manager-role
-  namespace: default
+  namespace: system
 rules:
 - apiGroups:
   - ""
   resources:
-  - configmap
+  - configmaps
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,3 +32,24 @@ rules:
   - get
   - patch
   - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: manager-role
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmap
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,18 +1,4 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: manager-role
-subjects:
-- kind: ServiceAccount
-  name: controller-manager
-  namespace: system
-
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manager-rolebinding

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -10,3 +10,17 @@ subjects:
 - kind: ServiceAccount
   name: controller-manager
   namespace: system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/controllers/guestbook_controller.go
+++ b/controllers/guestbook_controller.go
@@ -39,6 +39,7 @@ type GuestbookReconciler struct {
 //+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",namespace=default,resources=configmap,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/guestbook_controller.go
+++ b/controllers/guestbook_controller.go
@@ -58,7 +58,7 @@ func (r *GuestbookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	cm := &corev1.ConfigMap{}
 	_ = r.Client.Get(context.Background(), client.ObjectKey{
-		Namespace: "system",
+		Namespace: "guestbook-system",
 		Name:      "a-configmap",
 	}, cm)
 	log.Info("Loaded ConfigMap.", "ConfigMap", cm.Data)

--- a/controllers/guestbook_controller.go
+++ b/controllers/guestbook_controller.go
@@ -39,7 +39,7 @@ type GuestbookReconciler struct {
 //+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks/finalizers,verbs=update
-//+kubebuilder:rbac:groups="",namespace=default,resources=configmap,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,namespace=system,resources=configmaps,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -58,7 +58,7 @@ func (r *GuestbookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	cm := &corev1.ConfigMap{}
 	_ = r.Client.Get(context.Background(), client.ObjectKey{
-		Namespace: "default",
+		Namespace: "system",
 		Name:      "a-configmap",
 	}, cm)
 	log.Info("Loaded ConfigMap.", "ConfigMap", cm.Data)

--- a/controllers/guestbook_controller.go
+++ b/controllers/guestbook_controller.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -52,6 +54,13 @@ func (r *GuestbookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	log.Info("Reconcile called")
 	// your logic here
+
+	cm := &corev1.ConfigMap{}
+	_ = r.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "a-configmap",
+	}, cm)
+	log.Info("Loaded ConfigMap.", "ConfigMap", cm.Data)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/guestbook_controller.go
+++ b/controllers/guestbook_controller.go
@@ -36,9 +36,9 @@ type GuestbookReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=webapp.my.domain,resources=guestbooks/finalizers,verbs=update
+//+kubebuilder:rbac:groups=webapp.my.domain,namespace=system,resources=guestbooks,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=webapp.my.domain,namespace=system,resources=guestbooks/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=webapp.my.domain,namespace=system,resources=guestbooks/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,namespace=system,resources=configmaps,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v0.3.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
+	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
 	sigs.k8s.io/controller-runtime v0.7.2

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "ecaf1259.my.domain",
+		Namespace:              "guestbook-system",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
I'm trying to read a ConfigMap in GuestbookReconciler.Reconcile. I runs fine with `make run` but when I deploy it says it's forbidden:

```
$ make run
...
2021-05-06T23:05:17.478+0200	INFO	controllers.Guestbook	Reconcile called	{"guestbook": "default/guestbook-sample"}
2021-05-06T23:05:17.582+0200	INFO	controllers.Guestbook	Loaded ConfigMap.	{"guestbook": "default/guestbook-sample", "ConfigMap": {"foo":"bar"}}
```

```
$ make docker-build docker-push IMG=luebken/guestbook
$ make deploy IMG=luebken/guestbook

$ kubectl logs guestbook-controller-manager-67989bbbcd-wbfsp -n guestbook-system  manager
...
2021-05-06T21:11:49.422Z	INFO	controllers.Guestbook	Reconcile called	{"guestbook": "default/guestbook-sample"}
E0506 21:11:49.435990       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.2/tools/cache/reflector.go:156: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:guestbook-system:guestbook-controller-manager" cannot list resource "configmaps" in API group "" at the cluster scope
E0506 21:11:50.578774       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.2/tools/cache/reflector.go:156: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:guestbook-system:guestbook-controller-manager" cannot list resource "configmaps" in API group "" at the cluster scope
```